### PR TITLE
ci: let an explicit release version match the manifest, and bump the actions to v7

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -26,9 +26,9 @@ jobs:
         node-version: [22.x, 24.x, 26.x]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
@@ -45,7 +45,7 @@ jobs:
         run: npm run build ng-for-track-by-property-demo
       - name: Upload coverage
         if: matrix.node-version == '24.x'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage
           path: coverage/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,13 +45,13 @@ jobs:
           echo "::error::releases must be cut from ${{ github.event.repository.default_branch }}, got ${{ github.ref_name }}"
           exit 1
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           # the changelog needs the whole history and the tags
           fetch-depth: 0
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 24.x
           cache: npm
@@ -85,12 +85,15 @@ jobs:
               echo "::error::\"$REQUESTED\" is not a valid version"
               exit 1
             fi
+            # the manifest is often bumped by hand ahead of the release, so asking for
+            # exactly what it already holds is legal: "Fail if the version is already
+            # on npm" below is what rejects a genuine re-release
             HIGHEST="$(printf '%s\n%s\n' "$CURRENT" "$REQUESTED" | sort -V | tail -1)"
-            if [ "$REQUESTED" = "$CURRENT" ] || [ "$HIGHEST" != "$REQUESTED" ]; then
-              echo "::error::$REQUESTED is not greater than the current $CURRENT"
+            if [ "$HIGHEST" != "$REQUESTED" ]; then
+              echo "::error::$REQUESTED is older than the current $CURRENT"
               exit 1
             fi
-            npm version "$REQUESTED" --no-git-tag-version
+            npm version "$REQUESTED" --no-git-tag-version --allow-same-version
           else
             npm version "$BUMP" --no-git-tag-version
           fi
@@ -168,7 +171,7 @@ jobs:
 
       - name: Upload the dry-run output
         if: ${{ inputs.dry_run }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-dry-run-${{ steps.version.outputs.version }}
           path: |


### PR DESCRIPTION
The `Release` workflow assumed `package.json` still held the last **published** version and always bumped away from it. The Angular 22 upgrade already moved the manifest to `22.0.0` while npm is still on `21.0.1`, so the guard made `22.0.0` impossible to cut:

```
##[error]22.0.0 is not greater than the current 22.0.0
```

(Reproduced for real on ng-let, run [30186633092](https://github.com/nigrosimone/ng-let/actions/runs/30186633092). The same state exists in ng-let, ng-lock and ng-for-track-by-property.)

### Changes

- **Release guard** — only a version *older* than the manifest is refused now; asking for exactly what the manifest holds is allowed (`npm version --allow-same-version`). The `Fail if the version is already on npm` step, which runs right after, is what still rejects a genuine re-release.
- **Actions v4 → v7** — `actions/checkout`, `actions/setup-node` and `actions/upload-artifact` in both `node.js.yml` and `release.yml`. `@v4` runs on the Node 20 runtime GitHub is deprecating.

### Releasing after this

Type the version explicitly (`22.0.0`). Leaving the field empty makes `auto` bump to `22.1.0` and skip `22.0.0` — `auto`'s semantics are unchanged on purpose.

Note the repo has no `v*` tag yet, so `release.mjs` treats this as a first release and the generated CHANGELOG will cover the whole history. Harmless, and it settles down from `v22.0.0` onwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)